### PR TITLE
Show page title in Google search results; make URL messages more consistent across modules

### DIFF
--- a/willie/modules/rss.py
+++ b/willie/modules/rss.py
@@ -472,7 +472,7 @@ def read_feeds(bot, force=False):
                 continue
 
         # create message for new entry
-        message = u"[\x02{0}\x02] \x02{1}\x02 {2}".format(
+        message = u"[\x02{0}\x02] \x02{1}\x02 - {2}".format(
             colour_text(feed.name, feed.fg, feed.bg), entry.title, entry.link)
 
         # append update time if it exists, or published time if it doesn't

--- a/willie/modules/rss.py
+++ b/willie/modules/rss.py
@@ -472,7 +472,7 @@ def read_feeds(bot, force=False):
                 continue
 
         # create message for new entry
-        message = u"[\x02{0}\x02] \x02{1}\x02 - {2}".format(
+        message = u"[\x02{0}\x02] {1} | {2}".format(
             colour_text(feed.name, feed.fg, feed.bg), entry.title, entry.link)
 
         # append update time if it exists, or published time if it doesn't
@@ -485,7 +485,7 @@ def read_feeds(bot, force=False):
             if not tformat and bot.config.has_option('clock', 'time_format'):
                 tformat = bot.config.clock.time_format
 
-            message += " - {0}".format(timestamp.strftime(tformat or '%F - %T%Z'))
+            message += " | {0}".format(timestamp.strftime(tformat or '%F - %T%Z'))
 
         # print message
         bot.msg(feed.channel, message)

--- a/willie/modules/search.py
+++ b/willie/modules/search.py
@@ -71,7 +71,7 @@ def g(bot, trigger):
         return bot.reply('.g what?')
     uri, title = google_search_with_title(query)
     if uri:
-        bot.reply('[ {0} ] - {1}'.format(title, uri))
+        bot.reply('\x02{0}\x02 - {1}'.format(title, uri))
         bot.memory['last_seen_url'][trigger.sender] = uri
     elif uri is False:
         bot.reply("Problem getting data from Google.")

--- a/willie/modules/search.py
+++ b/willie/modules/search.py
@@ -32,6 +32,17 @@ def google_search(query):
         return False
 
 
+def google_search_with_title(query):
+    results = google_ajax(query)
+    try:
+        return (results['responseData']['results'][0]['unescapedUrl'],
+                results['responseData']['results'][0]['titleNoFormatting'])
+    except IndexError:
+        return None
+    except TypeError:
+        return False
+
+
 def google_count(query):
     results = google_ajax(query)
     if not 'responseData' in results:
@@ -58,9 +69,9 @@ def g(bot, trigger):
     query = trigger.group(2)
     if not query:
         return bot.reply('.g what?')
-    uri = google_search(query)
+    uri, title = google_search_with_title(query)
     if uri:
-        bot.reply(uri)
+        bot.reply('[ {0} ] - {1}'.format(title, uri))
         bot.memory['last_seen_url'][trigger.sender] = uri
     elif uri is False:
         bot.reply("Problem getting data from Google.")

--- a/willie/modules/search.py
+++ b/willie/modules/search.py
@@ -71,7 +71,7 @@ def g(bot, trigger):
         return bot.reply('.g what?')
     uri, title = google_search_with_title(query)
     if uri:
-        bot.reply('\x02{0}\x02 - {1}'.format(title, uri))
+        bot.reply('{0} | {1}'.format(title, uri))
         bot.memory['last_seen_url'][trigger.sender] = uri
     elif uri is False:
         bot.reply("Problem getting data from Google.")

--- a/willie/modules/search.py
+++ b/willie/modules/search.py
@@ -38,9 +38,9 @@ def google_search_with_title(query):
         return (results['responseData']['results'][0]['unescapedUrl'],
                 results['responseData']['results'][0]['titleNoFormatting'])
     except IndexError:
-        return None
+        return None, ''
     except TypeError:
-        return False
+        return False, ''
 
 
 def google_count(query):

--- a/willie/modules/url.py
+++ b/willie/modules/url.py
@@ -123,7 +123,7 @@ def title_auto(bot, trigger):
     bot.memory['last_seen_url'][trigger.sender] = urls[-1]
 
     for title, domain in results[:4]:
-        message = '[ %s ] - %s' % (title, domain)
+        message = '\x02{0}\x02 - {1}'.format(title, domain)
         # Guard against responding to other instances of this bot.
         if message != trigger:
             bot.say(message)

--- a/willie/modules/url.py
+++ b/willie/modules/url.py
@@ -107,7 +107,7 @@ def title_command(bot, trigger):
 
     results = process_urls(bot, trigger, urls)
     for title, domain in results[:4]:
-        bot.reply('\x02{0}\x02 - {1}'.format(title, domain))
+        bot.reply('{0} - {1}'.format(title, domain))
 
 
 @rule('(?u).*(https?://\S+).*')
@@ -125,7 +125,7 @@ def title_auto(bot, trigger):
     bot.memory['last_seen_url'][trigger.sender] = urls[-1]
 
     for title, domain in results[:4]:
-        message = '\x02{0}\x02 - {1}'.format(title, domain)
+        message = '{0} | {1}'.format(title, domain)
         # Guard against responding to other instances of this bot.
         if message != trigger:
             bot.say(message)

--- a/willie/modules/url.py
+++ b/willie/modules/url.py
@@ -8,6 +8,8 @@ Licensed under the Eiffel Forum License 2.
 http://willie.dftba.net
 """
 
+from __future__ import unicode_literals
+
 import re
 from htmlentitydefs import name2codepoint
 from willie import web, tools
@@ -105,7 +107,7 @@ def title_command(bot, trigger):
 
     results = process_urls(bot, trigger, urls)
     for title, domain in results[:4]:
-        bot.reply('[ %s ] - %s' % (title, domain))
+        bot.reply('\x02{0}\x02 - {1}'.format(title, domain))
 
 
 @rule('(?u).*(https?://\S+).*')

--- a/willie/modules/youtube.py
+++ b/willie/modules/youtube.py
@@ -130,12 +130,12 @@ def ytsearch(bot, trigger):
         bot.say("Sorry, I couldn't find the video you are looking for")
         return
 
-    message = ('\x02{0}\x02 | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
+    message = ('{0} | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
                '+{5} -{6} | Comments: {7} | {8}'
                .format(video_info['title'], video_info['length'], video_info['uploader'],
                        video_info['uploaded'], video_info['views'], video_info['likes'],
                        video_info['dislikes'], video_info['comments'], video_info['link']))
-    bot.say(HTMLParser().unescape(message))
+    bot.reply(HTMLParser().unescape(message))
 
 
 @rule('.*(youtube.com/watch\S*v=|youtu.be/)([\w-]+).*')
@@ -152,12 +152,12 @@ def ytinfo(bot, trigger, found_match=None):
         return
 
     #combine variables and print
-    message = ('\x02{0}\x02 | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
+    message = ('{0} | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
                '+{5} -{6} | Comments: {7} | {8}'
                .format(video_info['title'], video_info['length'], video_info['uploader'],
                        video_info['uploaded'], video_info['views'], video_info['likes'],
                        video_info['dislikes'], video_info['comments'], video_info['link']))
-    bot.say(HTMLParser().unescape(message))
+    bot.reply(HTMLParser().unescape(message))
 
 
 @commands('ytlast', 'ytnew', 'ytlatest')
@@ -171,7 +171,7 @@ def ytlast(bot, trigger):
     if video_info is 'err':
         return
 
-    message = ('\x02{0}\x02 | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
+    message = ('{0} | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
                '+{5} -{6} | Comments: {7} | {8}'
                .format(video_info['title'], video_info['length'], video_info['uploader'],
                        video_info['uploaded'], video_info['views'], video_info['likes'],

--- a/willie/modules/youtube.py
+++ b/willie/modules/youtube.py
@@ -61,9 +61,8 @@ def ytget(bot, trigger, uri):
     try:
         upraw = video_entry['published']['$t']
         #parse from current format to output format: DD/MM/yyyy, hh:mm
-        vid_info['uploaded'] = '%s/%s/%s, %s:%s' % (upraw[8:10], upraw[5:7],
-                                                  upraw[0:4], upraw[11:13],
-                                                  upraw[14:16])
+        vid_info['uploaded'] = '{0}-{1}-{2}, {3}:{4}'.format(upraw[0:4], upraw[8:10], upraw[5:7],
+                                                             upraw[11:13], upraw[14:16])
     except KeyError:
         vid_info['uploaded'] = 'N/A'
 
@@ -77,17 +76,11 @@ def ytget(bot, trigger, uri):
             hours = duration / (60 * 60)
             minutes = duration / 60 - (hours * 60)
             seconds = duration % 60
-            vid_info['length'] = ''
+
             if hours:
-                vid_info['length'] = str(hours) + 'hours'
-                if minutes or seconds:
-                    vid_info['length'] = vid_info['length'] + ' '
-            if minutes:
-                vid_info['length'] = vid_info['length'] + str(minutes) + 'mins'
-                if seconds:
-                    vid_info['length'] = vid_info['length'] + ' '
-            if seconds:
-                vid_info['length'] = vid_info['length'] + str(seconds) + 'secs'
+                vid_info['length'] = '{0}:{1:02}:{2:02}'.format(hours, minutes, seconds)
+            else:
+                vid_info['length'] = '{0}:{1:02}'.format(minutes, seconds)
     except KeyError:
         vid_info['length'] = 'N/A'
 
@@ -136,13 +129,12 @@ def ytsearch(bot, trigger):
     if video_info['link'] == 'N/A':
         bot.say("Sorry, I couldn't find the video you are looking for")
         return
-    message = ('[YT Search] Title: ' + video_info['title'] +
-              ' | Uploader: ' + video_info['uploader'] +
-              ' | Duration: ' + video_info['length'] +
-              ' | Uploaded: ' + video_info['uploaded'] +
-              ' | Views: ' + video_info['views'] +
-              ' | Link: ' + video_info['link'])
 
+    message = ('\x02{0}\x02 | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
+               '+{5} -{6} | Comments: {7} | {8}'
+               .format(video_info['title'], video_info['length'], video_info['uploader'],
+                       video_info['uploaded'], video_info['views'], video_info['likes'],
+                       video_info['dislikes'], video_info['comments'], video_info['link']))
     bot.say(HTMLParser().unescape(message))
 
 
@@ -160,15 +152,11 @@ def ytinfo(bot, trigger, found_match=None):
         return
 
     #combine variables and print
-    message = '[YouTube] Title: ' + video_info['title'] + \
-              ' | Uploader: ' + video_info['uploader'] + \
-              ' | Uploaded: ' + video_info['uploaded'] + \
-              ' | Duration: ' + video_info['length'] + \
-              ' | Views: ' + video_info['views'] + \
-              ' | Comments: ' + video_info['comments'] + \
-              ' | Likes: ' + video_info['likes'] + \
-              ' | Dislikes: ' + video_info['dislikes']
-
+    message = ('\x02{0}\x02 | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
+               '+{5} -{6} | Comments: {7} | {8}'
+               .format(video_info['title'], video_info['length'], video_info['uploader'],
+                       video_info['uploaded'], video_info['views'], video_info['likes'],
+                       video_info['dislikes'], video_info['comments'], video_info['link']))
     bot.say(HTMLParser().unescape(message))
 
 
@@ -183,12 +171,9 @@ def ytlast(bot, trigger):
     if video_info is 'err':
         return
 
-    message = ('[Latest Video] Title: ' + video_info['title'] +
-              ' | Duration: ' + video_info['length'] +
-              ' | Uploaded: ' + video_info['uploaded'] +
-              ' | Views: ' + video_info['views'] +
-              ' | Likes: ' + video_info['likes'] +
-              ' | Dislikes: ' + video_info['dislikes'] +
-              ' | Link: ' + video_info['link'])
-
+    message = ('\x02{0}\x02 | Length: {1} | Uploader: {2} | Uploaded: {3} | Views: {4} | '
+               '+{5} -{6} | Comments: {7} | {8}'
+               .format(video_info['title'], video_info['length'], video_info['uploader'],
+                       video_info['uploaded'], video_info['views'], video_info['likes'],
+                       video_info['dislikes'], video_info['comments'], video_info['link']))
     bot.say(HTMLParser().unescape(message))


### PR DESCRIPTION
Show page title in Google search results; make URL messages more consistent across modules

- .g command now displays the page title of the first search result.
- search, rss, and url modules now format messages in a more uniform way.