### PR TITLE
Have the bot use the correct prefix in examples, even if it's hard coded

### DIFF
--- a/willie/bot.py
+++ b/willie/bot.py
@@ -485,7 +485,17 @@ class Willie(irc.Bot):
                     else:
                         # The new format is a list of dicts.
                         example = func.example[0]["example"]
+
+
                     example = example.replace('$nickname', str(self.nick))
+		    if example[:1] != self.config.prefix:
+		        if example[:1] == ".":
+				# the example starts with a dot, but that
+				# isn't the prefix we're using
+				# replace a dot with the correct prefix
+				example = self.config.prefix + example[1:]
+			else:
+				example = self.config.prefix + example
                 if doc or example:
                     for command in func.commands:
                         self.doc[command] = (doc, example)


### PR DESCRIPTION
Basically this just looks at the ```@example``` decorator's text to ensure that if the prefix set in config is different or missing, it gets correctly prepended to the help text.

My users were very confused when I changed the prefix to @ but the help commands still said to use "." :)

Also, I *love* this bot.  Switching from Hubot to Willie was a huge time-saver for me!