### PR TITLE
use integer division for python 3 compatibility

### DIFF
--- a/willie/modules/youtube.py
+++ b/willie/modules/youtube.py
@@ -84,8 +84,8 @@ def ytget(bot, trigger, uri):
         if duration < 1:
             vid_info['length'] = 'LIVE'
         else:
-            hours = duration / (60 * 60)
-            minutes = duration / 60 - (hours * 60)
+            hours = duration // (60 * 60)
+            minutes = duration // 60 - (hours * 60)
             seconds = duration % 60
             vid_info['length'] = ''
             if hours:

--- a/willie/modules/youtube.py
+++ b/willie/modules/youtube.py
@@ -10,7 +10,7 @@ http://willie.dfbta.net
 
 This module will respond to .yt and .youtube commands and searches the youtubes.
 """
-from __future__ import unicode_literals
+from __future__ import unicode_literals, division
 
 from willie import web, tools
 from willie.module import rule, commands, example


### PR DESCRIPTION
in python 3, the / operator can take two integers and produce a float.

This leads to things like "Duration: 0.025833333333333333hours 33secs"

// is always integer division, in both python2 and python3