### PR TITLE
[youtube] Fixed video duration format when running on python3

### DIFF
--- a/willie/modules/youtube.py
+++ b/willie/modules/youtube.py
@@ -84,8 +84,8 @@ def ytget(bot, trigger, uri):
         if duration < 1:
             vid_info['length'] = 'LIVE'
         else:
-            hours = duration / (60 * 60)
-            minutes = duration / 60 - (hours * 60)
+            hours = duration // (60 * 60)
+            minutes = duration // 60 - (hours * 60)
             seconds = duration % 60
             vid_info['length'] = ''
             if hours:


### PR DESCRIPTION
Compare: 
python 2: 
[YT Search] Title: Test Brytyjskich Ciast | Uploader: paei100 | **Duration: 9mins 6secs** | Uploaded: 05/01/2015, 17:49 | Views: 109,733 | Link: http://youtu.be/p9a0LgQv_Gw
python 3:
[YT Search] Title: Test Brytyjskich Ciast | Uploader: paei100 | **Duration: 0.15166666666666667hours 6secs** | Uploaded: 05/01/2015, 17:49 | Views: 109,733 | Link: http://youtu.be/p9a0LgQv_Gw

This is caused by python 3 assuming float division even when both operands are integer. Changing the division to be explicitly integer fixes the issue.