### PR TITLE
[youtube] Fixed video duration format when running on python3 in 5.0

### DIFF
--- a/willie/modules/youtube.py
+++ b/willie/modules/youtube.py
@@ -84,8 +84,8 @@ def ytget(bot, trigger, uri):
         if duration < 1:
             vid_info['length'] = 'LIVE'
         else:
-            hours = duration / (60 * 60)
-            minutes = duration / 60 - (hours * 60)
+            hours = duration // (60 * 60)
+            minutes = duration // 60 - (hours * 60)
             seconds = duration % 60
             vid_info['length'] = ''
             if hours:


### PR DESCRIPTION
This is identical to PR #703, but the fix is in the master branch as opposed to 4.6.