### PR TITLE
[clock] Fix unclear message when using .settf

### DIFF
--- a/willie/modules/clock.py
+++ b/willie/modules/clock.py
@@ -82,7 +82,7 @@ def update_user_format(bot, trigger):
         bot.reply("What format do you want me to use? Try using"
                   " http://strftime.net to make one.")
 
-    tz = get_timezone(bot.db, bot.config, None, None, trigger.sender)
+    tz = get_timezone(bot.db, bot.config, None, trigger.nick, trigger.sender)
 
     # Get old format as back-up
     old_format = bot.db.get_nick_value(trigger.nick, 'time_format')


### PR DESCRIPTION
When you would set your time format, it would give an example response like
```
<maxpowa> .settf %F %r (%Z)
<Inumuta> maxpowa: Got it. Your time will now appear as 2015-01-25 12:04:35 AM (). (If the timezone is wrong, you might try the settz command)
```
instead of using your previously set time zone like
```
<maxpowa> .settf %F %r (%Z)
<Inumuta> maxpowa: Got it. Your time will now appear as 2015-01-25 04:05:38 PM (PST). (If the timezone is wrong, you might try the settz command)
```