### PR TITLE
Add the option to use the bot's preferred timezone for logs.

### DIFF
--- a/willie/modules/chanlogs.py
+++ b/willie/modules/chanlogs.py
@@ -46,18 +46,20 @@ def configure(config):
         # could ask if user wants to customize message templates,
         # but that seems unnecessary
 
+
 def get_datetime(bot):
     """
     Returns a datetime object of the current time.
     """
     dt = datetime.utcnow()
     if pytz:
-        dt = dt.replace(tzinfo = timezone('UTC'))
+        dt = dt.replace(tzinfo=timezone('UTC'))
         if bot.config.chanlogs.localtime:
             dt = dt.astimezone(timezone(bot.config.clock.tz))
     if not bot.config.chanlogs.microseconds:
         dt = dt.replace(microsecond=0)
     return dt
+
 
 def get_fpath(bot, trigger, channel=None):
     """

--- a/willie/modules/chanlogs.py
+++ b/willie/modules/chanlogs.py
@@ -13,6 +13,12 @@ import os.path
 import threading
 import sys
 from datetime import datetime
+try:
+    from pytz import timezone
+    from pytz import all_timezones
+    import pytz
+except ImportError:
+    pytz = None
 import willie.module
 import willie.tools
 from willie.config import ConfigurationError
@@ -36,9 +42,22 @@ def configure(config):
         config.add_option("chanlogs", "by_day", "Split log files by day", default=True)
         config.add_option("chanlogs", "privmsg", "Record private messages", default=False)
         config.add_option("chanlogs", "microseconds", "Microsecond precision", default=False)
+        config.add_option("chanlogs", "localtime", "Attempt to use preferred timezone", default=False)
         # could ask if user wants to customize message templates,
         # but that seems unnecessary
 
+def get_datetime(bot):
+    """
+    Returns a datetime object of the current time.
+    """
+    dt = datetime.utcnow()
+    if pytz:
+        dt = dt.replace(tzinfo = timezone('UTC'))
+        if bot.config.chanlogs.localtime:
+            dt = dt.astimezone(timezone(bot.config.clock.tz))
+    if not bot.config.chanlogs.microseconds:
+        dt = dt.replace(microsecond=0)
+    return dt
 
 def get_fpath(bot, trigger, channel=None):
     """
@@ -49,9 +68,7 @@ def get_fpath(bot, trigger, channel=None):
     channel = channel or trigger.sender
     channel = channel.lstrip("#")
 
-    dt = datetime.utcnow()
-    if not bot.config.chanlogs.microseconds:
-        dt = dt.replace(microsecond=0)
+    dt = get_datetime(bot)
     if bot.config.chanlogs.by_day:
         fname = "{channel}-{date}.log".format(channel=channel, date=dt.date().isoformat())
     else:
@@ -60,9 +77,7 @@ def get_fpath(bot, trigger, channel=None):
 
 
 def _format_template(tpl, bot, trigger, **kwargs):
-    dt = datetime.utcnow()
-    if not bot.config.chanlogs.microseconds:
-        dt = dt.replace(microsecond=0)
+    dt = get_datetime(bot)
 
     formatted = tpl.format(
         trigger=trigger, datetime=dt.isoformat(),


### PR DESCRIPTION
This adds an option to use the clock module's timezone for storing logs.

I'm not sure if this is done properly as I'm not very well versed in Python, but I figured I'd give it a shot since everybody in my channel is in America/Los_Angeles and was complaining about logs being split in the middle of when we tend to be active. It appears to work properly, when pytz is installed, and falls back to the old behaviour when it isn't.