### PR TITLE
[trigger] Fix CTCP -> IRCv3 Intent conversion

### DIFF
--- a/willie/trigger.py
+++ b/willie/trigger.py
@@ -15,7 +15,7 @@ class PreTrigger(object):
     """A parsed message from the server, which has not been matched against
     any rules."""
     component_regex = re.compile(r'([^!]*)!?([^@]*)@?(.*)')
-    intent_regex = re.compile('\x01(\\S+) (.*)\x01')
+    intent_regex = re.compile('\x01(\\S+)(?: (.*))?\x01')
 
     def __init__(self, own_nick, line):
         """own_nick is the bot's nick, needed to correctly parse sender.


### PR DESCRIPTION
CTCP messages that are just single word messages weren't properly being converted into intents, because the current system was expecting a following section. Some CTCP messages (TIME, USERINFO) wouldn't usually be sent with trailing information, causing the old regex to miss converting them into intents.