### PR TITLE
Do not check if running as root

### DIFF
--- a/willie.py
+++ b/willie.py
@@ -91,18 +91,6 @@ def main(argv=None):
                             dest="version", help="Show version number and exit")
         opts = parser.parse_args()
 
-        # Step Two: "Do not run as root" checks.
-        try:
-            # Linux/Mac
-            if os.getuid() == 0 or os.geteuid() == 0:
-                stderr('Error: Do not run Willie with root privileges.')
-                sys.exit(1)
-        except AttributeError:
-            # Windows
-            if os.environ.get("USERNAME") == "Administrator":
-                stderr('Error: Do not run Willie as Administrator.')
-                sys.exit(1)
-
         if opts.version:
             py_ver = '%s.%s.%s' % (sys.version_info.major,
                                    sys.version_info.minor,


### PR DESCRIPTION
This commit removes the checks for uid != 0, which prevent running
willie in environments without users (such as Docker, or embedded
systems)