### PR TITLE
Drop locking methods from WillieMemory

### DIFF
--- a/willie/tools/__init__.py
+++ b/willie/tools/__init__.py
@@ -324,11 +324,6 @@ class WillieMemory(dict):
         """Backwards compatability with 3.x, use `in` operator instead."""
         return self.__contains__(key)
 
-    def unlock(self):
-        """Release the write lock."""
-        return self.lock.release()
-
-
 class WillieMemoryWithDefault(defaultdict):
     """Same as WillieMemory, but subclasses from collections.defaultdict."""
     def __init__(self, *args):
@@ -355,7 +350,3 @@ class WillieMemoryWithDefault(defaultdict):
     def contains(self, key):
         """Backwards compatability with 3.x, use `in` operator instead."""
         return self.__contains__(key)
-
-    def unlock(self):
-        """Release the write lock."""
-        return self.lock.release()

--- a/willie/tools/__init__.py
+++ b/willie/tools/__init__.py
@@ -356,10 +356,6 @@ class WillieMemoryWithDefault(defaultdict):
         """Backwards compatability with 3.x, use `in` operator instead."""
         return self.__contains__(key)
 
-    def lock(self):
-        """Lock this instance from writes. Useful if you want to iterate."""
-        return self.lock.acquire()
-
     def unlock(self):
         """Release the write lock."""
         return self.lock.release()


### PR DESCRIPTION
Drop some useless locking methods on WillieMemory and WillieMemoryWithDefault. Instead of these methods, the memory.lock object can be used directly.