### PR TITLE
[coretasks] Make the anti spam module aware of passing time (ish)

### DIFF
--- a/willie/coretasks.py
+++ b/willie/coretasks.py
@@ -502,3 +502,16 @@ def blocks(bot, trigger):
             return
     else:
         bot.reply(STRINGS['huh'])
+
+@willie.module.interval(600)
+def flood_decay(bot):
+    ''' A crude first attempt at making the anti-spam unit aware of time '''
+    try:
+        bot.sending.acquire()
+        
+        for recipient_id in bot.stack.iterkeys():
+            if self.stack[recipient_id]:
+                self.stack[recipient_id].pop(0)
+    
+    finally:
+        bot.sending.release()


### PR DESCRIPTION
  The recent issue opened by the one who wanted to have willie say the same thing every 15 seconds reminded me of a previous concern I had regarding willie's anti-spam detection. Namely, that if something was said 5 times 10 hours ago and nothing has been said since, the next time it is said willie will print '...'. At that point its not spam protection, its just annoying. This clips the last message willie remembers for each channel every 10 minutes (this should be changed to a more useful number) to prevent that without affecting spam detection too much