### PR TITLE
Allow willie to be run as root

### DIFF
--- a/willie.py
+++ b/willie.py
@@ -87,21 +87,24 @@ def main(argv=None):
                             dest='mod_wizard', help=(
                                 'Run the configuration wizard, but only for the '
                                 'module configuration options.'))
+        parser.add_argument('--allow-root', action="store_true", dest="root",
+                            help="Allow Willie to run as root or administrator.")
         parser.add_argument('-v', '--version', action="store_true",
                             dest="version", help="Show version number and exit")
         opts = parser.parse_args()
 
         # Step Two: "Do not run as root" checks.
-        try:
-            # Linux/Mac
-            if os.getuid() == 0 or os.geteuid() == 0:
-                stderr('Error: Do not run Willie with root privileges.')
-                sys.exit(1)
-        except AttributeError:
-            # Windows
-            if os.environ.get("USERNAME") == "Administrator":
-                stderr('Error: Do not run Willie as Administrator.')
-                sys.exit(1)
+        if not ops.root:
+            try:
+                # Linux/Mac
+                if os.getuid() == 0 or os.geteuid() == 0:
+                    stderr('Error: Do not run Willie with root privileges.')
+                    sys.exit(1)
+            except AttributeError:
+                # Windows
+                if os.environ.get("USERNAME") == "Administrator":
+                    stderr('Error: Do not run Willie as Administrator.')
+                    sys.exit(1)
 
         if opts.version:
             py_ver = '%s.%s.%s' % (sys.version_info.major,

--- a/willie.py
+++ b/willie.py
@@ -94,7 +94,7 @@ def main(argv=None):
         opts = parser.parse_args()
 
         # Step Two: "Do not run as root" checks.
-        if not ops.root:
+        if not opts.root:
             try:
                 # Linux/Mac
                 if os.getuid() == 0 or os.geteuid() == 0:


### PR DESCRIPTION
I was trying to run willie from inside a docker container and the uid check caught me out. This gives an option to turn it off.