### PR TITLE
make .seen replies for CTCP ACTIONs say "doing nick message"

### DIFF
--- a/willie/modules/seen.py
+++ b/willie/modules/seen.py
@@ -27,6 +27,7 @@ def seen(bot, trigger):
     if timestamp:
         channel = bot.db.get_nick_value(nick, 'seen_channel')
         message = bot.db.get_nick_value(nick, 'seen_message')
+        action = bot.db.get_nick_value(nick, 'seen_action')
 
         tz = get_timezone(bot.db, bot.config, None, trigger.nick,
                           trigger.sender)
@@ -36,7 +37,10 @@ def seen(bot, trigger):
 
         msg = "I last saw {} at {}".format(nick, timestamp)
         if Identifier(channel) == trigger.sender:
-            msg = msg + " in here, saying " + message
+	    if action:
+                msg = msg + " in here, doing " + nick + " " + message
+	    else:
+                msg = msg + " in here, saying " + message
         else:
             msg += " in another channel."
         bot.say(str(trigger.nick) + ': ' + msg)
@@ -52,3 +56,4 @@ def note(bot, trigger):
         bot.db.set_nick_value(trigger.nick, 'seen_timestamp', time.time())
         bot.db.set_nick_value(trigger.nick, 'seen_channel', trigger.sender)
         bot.db.set_nick_value(trigger.nick, 'seen_message', trigger)
+        bot.db.set_nick_value(trigger.nick, 'seen_action', 'intent' in trigger.tags)

--- a/willie/modules/seen.py
+++ b/willie/modules/seen.py
@@ -37,9 +37,9 @@ def seen(bot, trigger):
 
         msg = "I last saw {} at {}".format(nick, timestamp)
         if Identifier(channel) == trigger.sender:
-	    if action:
+            if action:
                 msg = msg + " in here, doing " + nick + " " + message
-	    else:
+            else:
                 msg = msg + " in here, saying " + message
         else:
             msg += " in another channel."


### PR DESCRIPTION
This is an update to the ".seen" feature.

The old behavior is /me actions (CTCP ACTIONs) would be saved in the .seen feature and re-shown as the user saying something:
9:42:26 AM  * jnmtx hehe 
9:42:28 AM  @jnmtx  .seen jnmtx 
9:42:29 AM  jwbot  jnmtx: I last saw jnmtx at 2015-05-19 - 14:42:25 in here, saying hehe 

The new behavior makes .seen replies for CTCP ACTIONs say "doing nick message", but leaves .seen replies for PRIVMSG to channel the same ("saying message"):
9:49:45 AM  * jm hehe 
9:49:48 AM  @jnmtx  .seen jm 
9:49:48 AM  jwbot  jnmtx: I last saw jm at 2015-05-19 - 14:49:44 in here, doing jm hehe 

9:50:06 AM  jm  what's up? 
9:50:11 AM@jnmtx  .seen jm 
9:50:11 AM  jwbot  jnmtx: I last saw jm at 2015-05-19 - 14:50:05 in here, saying what's up? 

That's it.
Thank you for considering this minor feature tweak.