### PR TITLE
[config] Try to parse ListAttribute as list before excepting (fix #841)

### DIFF
--- a/willie/config/types.py
+++ b/willie/config/types.py
@@ -221,7 +221,9 @@ class ListAttribute(BaseValidated):
 
     def serialize(self, value):
         if not isinstance(value, list):
-            raise ValueError('ListAttribute value must be a list.')
+            value = self.parse(value)
+            if not isinstance(value, list):
+                raise ValueError('ListAttribute value must be a list.')
         return ','.join(value)
 
     def configure(self, prompt, default):


### PR DESCRIPTION
ListAttribute.serialize() should try to parse the value it is given into a list before giving up. This fixes #841 and allows the admin module to properly set list values like `core.admins`.